### PR TITLE
Bean flow3

### DIFF
--- a/src/main/java/jp/ossc/nimbus/core/MetaData.java
+++ b/src/main/java/jp/ossc/nimbus/core/MetaData.java
@@ -485,6 +485,19 @@ public abstract class MetaData implements Serializable, Cloneable{
      * @return 要素の内容
      */
     public static String getElementContent(Element element, String defaultStr){
+        return getElementContent(element, false, defaultStr);
+    }
+    
+    /**
+     * 指定した要素の内容を取得する。<p>
+     * 内容が空の場合は、引数で指定されたdefaultStrを返す。<br>
+     *
+     * @param element 要素
+     * @param isComment コメントされた要素の内容を取得する場合、true
+     * @param defaultStr デフォルト値
+     * @return 要素の内容
+     */
+    public static String getElementContent(Element element, boolean isComment, String defaultStr){
         if(element == null){
             return defaultStr;
         }
@@ -495,14 +508,26 @@ public abstract class MetaData implements Serializable, Cloneable{
         }
         String result = "";
         for(int i = 0, max = children.getLength(); i < max; i++){
-            if(children.item(i).getNodeType() == Node.TEXT_NODE
-                 || children.item(i).getNodeType() == Node.CDATA_SECTION_NODE
-            ){
-                result += children.item(i).getNodeValue();
-            }else if(children.item(i).getNodeType() == Node.COMMENT_NODE){
-                // コメントは無視
+            Node currentNode = children.item(i);
+            if(isComment){
+                switch(currentNode.getNodeType()){
+                case Node.COMMENT_NODE:
+                    result += currentNode.getNodeValue();
+                    break;
+                default:
+                }
             }else{
-                result += children.item(i).getFirstChild();
+                switch(currentNode.getNodeType()){
+                case Node.COMMENT_NODE:
+                    // コメントは無視
+                    break;
+                case Node.TEXT_NODE:
+                case Node.CDATA_SECTION_NODE:
+                    result += currentNode.getNodeValue();
+                    break;
+                default:
+                    result += currentNode.getFirstChild();
+                }
             }
         }
         return trim(result);

--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerAccessImpl2.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerAccessImpl2.java
@@ -6508,10 +6508,6 @@ public class BeanFlowInvokerAccessImpl2 extends MetaData implements BeanFlowInvo
                 beforeToken = str;
             }
 
-            if(keyList.size() == 0){
-                throw new IllegalArgumentException(cond);
-            }
-
             if(factoryCallBack.getTestInterpreter() == null){
                 expression = ExpressionFactory.createExpression(condBuf.toString());
             }else{

--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerAccessImpl2.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerAccessImpl2.java
@@ -6203,8 +6203,7 @@ public class BeanFlowInvokerAccessImpl2 extends MetaData implements BeanFlowInvo
                     "TemplateEngine is null."
                 );
             }
-            Map vars = new HashMap();
-            vars.putAll(context);
+            Map vars = context.getInterpreterContext();
             vars.put(INPUT, context.input);
             vars.put(TARGET, context.getThis());
             vars.put(VAR, context.vars);

--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerAccessImpl2.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerAccessImpl2.java
@@ -6338,7 +6338,7 @@ public class BeanFlowInvokerAccessImpl2 extends MetaData implements BeanFlowInvo
         }
         
         public Object put(Object key, Object value){
-            interpreterContext.put(key, value);
+            interpreterContext.put(key, ((StepContext)value).result);
             return super.put(key, value);
         }
         

--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerFactoryCallBack.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerFactoryCallBack.java
@@ -104,8 +104,11 @@ public interface BeanFlowInvokerFactoryCallBack {
     
     public Interpreter getInterpreter();
     public Interpreter getTestInterpreter();
+    public Interpreter getExpressionInterpreter();
+    
     public TransactionManagerFactory getTransactionManagerFactory();
     public TemplateEngine getTemplateEngine();
     
     public QueueHandlerContainer getAsynchInvokeQueueHandlerContainer();
+    public String replaceProperty(String textValue);
 }

--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/DefaultBeanFlowInvokerFactoryService.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/DefaultBeanFlowInvokerFactoryService.java
@@ -147,6 +147,10 @@ public class DefaultBeanFlowInvokerFactoryService extends ServiceBase
 
     private Interpreter testInterpreter;
 
+    private ServiceName expressionInterpreterServiceName;
+
+    private Interpreter expressionInterpreter;
+
     private ServiceName templateEngineServiceName;
 
     private TemplateEngine templateEngine;
@@ -260,6 +264,16 @@ public class DefaultBeanFlowInvokerFactoryService extends ServiceBase
     // DefaultBeanFlowInvokerFactoryServiceMBeanのJavaDoc
     public ServiceName getTestInterpreterServiceName(){
         return testInterpreterServiceName;
+    }
+
+    // DefaultBeanFlowInvokerFactoryServiceMBeanのJavaDoc
+    public void setExpressionInterpreterServiceName(ServiceName name){
+        expressionInterpreterServiceName = name;
+    }
+
+    // DefaultBeanFlowInvokerFactoryServiceMBeanのJavaDoc
+    public ServiceName getExpressionInterpreterServiceName(){
+        return expressionInterpreterServiceName;
     }
 
     // DefaultBeanFlowInvokerFactoryServiceMBeanのJavaDoc
@@ -637,6 +651,10 @@ public class DefaultBeanFlowInvokerFactoryService extends ServiceBase
             testInterpreter = (Interpreter)ServiceManagerFactory.getServiceObject(testInterpreterServiceName);
         }
 
+        if(expressionInterpreterServiceName != null){
+            expressionInterpreter = (Interpreter)ServiceManagerFactory.getServiceObject(expressionInterpreterServiceName);
+        }
+
         if(templateEngineServiceName != null){
             templateEngine = (TemplateEngine)ServiceManagerFactory.getServiceObject(templateEngineServiceName);
         }
@@ -797,7 +815,7 @@ public class DefaultBeanFlowInvokerFactoryService extends ServiceBase
         return blFlowConfig;
     }
 
-    private String replaceProperty(String textValue){
+    public String replaceProperty(String textValue){
 
         // システムプロパティの置換
         textValue = Utility.replaceSystemProperty(textValue);
@@ -1098,6 +1116,10 @@ public class DefaultBeanFlowInvokerFactoryService extends ServiceBase
     public Interpreter getTestInterpreter(){
         return testInterpreter;
     }
+    
+    public Interpreter getExpressionInterpreter(){
+        return expressionInterpreter == null ? getTestInterpreter() : expressionInterpreter;
+    }
 
     // BeanFlowInvokerFactoryCallBackのJavaDoc
     public TemplateEngine getTemplateEngine(){
@@ -1120,6 +1142,15 @@ public class DefaultBeanFlowInvokerFactoryService extends ServiceBase
      */
     public void setTestInterpreter(Interpreter interpreter) {
         this.testInterpreter = interpreter;
+    }
+
+    /**
+     * expression評価用の{@link Interpreter}を設定する。<p>
+     *
+     * @param interpreter Interpreter
+     */
+    public void setExpressionInterpreter(Interpreter interpreter) {
+        this.expressionInterpreter = interpreter;
     }
 
     // BeanFlowInvokerFactoryCallBackのJavaDoc

--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/DefaultBeanFlowInvokerFactoryServiceMBean.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/DefaultBeanFlowInvokerFactoryServiceMBean.java
@@ -144,6 +144,20 @@ public interface DefaultBeanFlowInvokerFactoryServiceMBean
     public ServiceName getTestInterpreterServiceName();
     
     /**
+     * expression要素評価用の{@link jp.ossc.nimbus.service.interpreter.Interpreter Interpreter}サービスのサービス名を設定する。<p>
+     * 
+     * @param name Interpreterサービスのサービス名
+     */
+    public void setExpressionInterpreterServiceName(ServiceName name);
+    
+    /**
+     * expression要素評価用の{@link jp.ossc.nimbus.service.interpreter.Interpreter Interpreter}サービスのサービス名を取得する。<p>
+     * 
+     * @return Interpreterサービスのサービス名
+     */
+    public ServiceName getExpressionInterpreterServiceName();
+    
+    /**
      * {@link jp.ossc.nimbus.service.template.TemplateEngine TemplateEngine}サービスのサービス名を設定する。<p>
      * 
      * @param name TemplateEngineサービスのサービス名

--- a/src/main/resources/jp/ossc/nimbus/service/beancontrol/beanflow_1_0.dtd
+++ b/src/main/resources/jp/ossc/nimbus/service/beancontrol/beanflow_1_0.dtd
@@ -12,7 +12,7 @@ The DOCTYPE is:
 
 <!-- flow—v‘f‚ÍA‹Æ–±ƒtƒ[‚ð’è‹`‚·‚é—v‘f‚Å‚·B
 -->
-<!ELEMENT flow (alias* | override* | resource* | step* | callflow* | reply* | switch* | if* | for* | while* | catch* | finally? | return?)*>
+<!ELEMENT flow (alias* | override* | input-def* | resource* | step* | callflow* | reply* | switch* | if* | for* | while* | catch* | finally? | return?)*>
 
 <!-- name‘®«‚ÍAflow—v‘f‚Å’è‹`‚·‚é‹Æ–±ƒtƒ[‚ÌˆêˆÓ‚È–¼‘O‚ð’è‹`‚µ‚Ü‚·B
 -->
@@ -285,7 +285,7 @@ The DOCTYPE is:
  ‚±‚Ì—v‘f‚É‚æ‚Á‚Ä’è‹`‚³‚ê‚½ƒXƒeƒbƒvŒ‹‰Ê‚ÍAstep-ref—v‘f‚ÅŽQÆ‚·‚éŽ–‚ª‚Å‚«‚Ü‚·B
  ’A‚µAstep—v‘f‚Éname‘®«‚ðŽw’è‚µ‚È‚¯‚ê‚Î‚È‚è‚Ü‚¹‚ñB
 -->
-<!ELEMENT result (#PCDATA | attribute | field | invoke | this | input | static-invoke | static-field-ref | object | expression | step-ref | var)*>
+<!ELEMENT result (#PCDATA | attribute | field | invoke | this | input | static-invoke | static-field-ref | object | expression | step-ref | var | service-ref)*>
 
 <!-- journal‘®«‚ÍAresult—v‘f‚ÅƒWƒƒ[ƒiƒ‹‚ðo—Í‚·‚é‚©‚Ç‚¤‚©‚ð’è‹`‚µ‚Ü‚·B
  ‚±‚Ì—v‘f‚ÌŽq—v‘f‘S‚Ä‚É“K—p‚³‚ê‚éB
@@ -412,7 +412,7 @@ The DOCTYPE is:
 <!-- case—v‘f‚ÍAswitch—v‘f‚É‚æ‚éðŒ‘I‘ð’†‚Ì1ðŒ‚ð’è‹`‚µ‚Ü‚·B
  ‚±‚ÌðŒ‚Éˆê’v‚·‚éê‡‚Ìˆ—‚ðAŽq—v‘f‚É’è‹`‚µ‚Ü‚·B
 -->
-<!ELEMENT case (step* | callflow* | reply* | switch* | if* | for* | while* | break? | continue? | return? | throw?)*>
+<!ELEMENT case (test? | step* | callflow* | reply* | switch* | if* | for* | while* | break? | continue? | return? | throw?)*>
 
 <!-- test‘®«‚ÍAcase—v‘f‚ª•\‚·ðŒ‚ð’è‹`‚µ‚Ü‚·B
  ‚±‚Ì‘®«‚Ì’l‚É‚ÍA@‚ÅˆÍ‚ñ‚¾ƒL[‚Æ‚»‚ÌƒL[’l‚É‘Î‚·‚éðŒŽ®‚ð‹Lq‚µ‚Ü‚·B
@@ -422,6 +422,7 @@ The DOCTYPE is:
    EƒXƒeƒbƒv‚Ì‘ÎÛ : @ƒXƒeƒbƒv–¼.target@
    EƒXƒeƒbƒv‚ÌŒ‹‰Ê : @ƒXƒeƒbƒv–¼.result@ ‚Ü‚½‚Í @ƒXƒeƒbƒv–¼@
    E‚±‚Ì—v‘f‚Ìe—v‘fƒXƒeƒbƒv‚Ì‘ÎÛF@this@
+   EƒXƒeƒbƒvŽ©‘ÌFƒXƒeƒbƒv–¼
   ‚Ü‚½AƒXƒeƒbƒv‚Ì‘ÎÛ‹y‚ÑŒ‹‰Ê‚ÌƒvƒƒpƒeƒB‚ðŽQÆ‚·‚éŽ–‚à‚Å‚«‚Ü‚·B
   ‚»‚Ìê‡‚ÍAã‹L‚Ì•\Œ»‚ÌŒã‚ÉAƒvƒƒpƒeƒB‚ð•\Œ»‚·‚é•¶Žš—ñ‚ðŽw’è‚µ‚Ü‚·B
   ‚±‚±‚ÅŒ¾‚¤AƒvƒƒpƒeƒB‚ÌŠT”O‚ÍAJava Beans‚ÌƒvƒƒpƒeƒB‚ÌŠT”O‚æ‚èL‚­Ajp.ossc.nimbus.beans.PropertyFactory‚Ì‹K–ñ‚É]‚¢‚Ü‚·B
@@ -433,14 +434,14 @@ The DOCTYPE is:
    ƒXƒeƒbƒv‚ÌŽQÆ‚Æ“¯—l‚Éƒtƒ[‚Ì“ü—Í‚ÌƒvƒƒpƒeƒB‚àŽw’è‚Å‚«‚Ü‚·B
    
  (3)ŒJ‚è•Ô‚µ•Ï”
-   ŒJ‚è•Ô‚µ•Ï”‚ðŽQÆ‚·‚éê‡‚É‚ÍA@var(•Ï”–¼)@‚ÆŽw’è‚µ‚Ü‚·B
+   ŒJ‚è•Ô‚µ•Ï”‚ðŽQÆ‚·‚éê‡‚É‚ÍA@var(•Ï”–¼)@‚ÆŽw’è‚µ‚Ü‚·B‚Ü‚½A•Ï”–¼‚Ì‚Ý‚Å‚àŽQÆ‚Å‚«‚é‚æ‚¤‚É‚È‚è‚Ü‚µ‚½B
    ƒXƒeƒbƒv‚ÌŽQÆ‚Æ“¯—l‚ÉŒJ‚è•Ô‚µ•Ï”‚ÌƒvƒƒpƒeƒB‚àŽw’è‚Å‚«‚Ü‚·B
  
  ðŒŽ®‚ÍAThe Apache Jakarta Project‚Ì Commons Jexl(http://jakarta.apache.org/commons/jexl/)‚ðŽg—p‚µ‚Ü‚·B
  ‚Ü‚½AðŒŽ®‚ÌŒ‹‰Ê‚Í•K‚¸boolean‚Å‚È‚¯‚ê‚Î‚È‚è‚Ü‚¹‚ñB
    —á : test='@ƒXƒeƒbƒv–¼.hoge[0].fuga@ == "HOGE"'
 -->
-<!ATTLIST case test CDATA #REQUIRED>
+<!ATTLIST case test CDATA #IMPLIED>
 
 <!-- nullCheck‘®«‚ÍAtest‘®«‚ÅAƒvƒƒpƒeƒB•\Œ»‚ÌƒL[‚ðŽw’è‚µ‚½ê‡‚ÉAƒlƒXƒg‚³‚ê‚½ƒvƒƒpƒeƒB‚ªnull‚©‚Ç‚¤‚©‚ðƒ`ƒFƒbƒN‚·‚é‚©‚Ç‚¤‚©‚ðÝ’è‚µ‚Ü‚·B
  true‚ðÝ’è‚µ‚½ê‡‚ÍAƒlƒXƒg‚³‚ê‚½ƒvƒƒpƒeƒB‚ªnull‚Ìê‡Ajp.ossc.nimbus.beans.NoSuchPropertyException‚ª”­¶‚µ‚Ü‚·B
@@ -457,12 +458,12 @@ The DOCTYPE is:
 <!-- if—v‘f‚ÍAˆê’èðŒ‰º‚Å‚Ìˆ—‚ð’è‹`‚µ‚Ü‚·B
  ‚±‚ÌðŒ‚Éˆê’v‚·‚éê‡‚Ìˆ—‚ðAŽq—v‘f‚É’è‹`‚µ‚Ü‚·B
 -->
-<!ELEMENT if (step* | callflow* | reply* | switch* | if* | for* | while* | break? | continue? | return? | throw?)*>
+<!ELEMENT if (test? | step* | callflow* | reply* | switch* | if* | for* | while* | break? | continue? | return? | throw?)*>
 
 <!-- test‘®«‚ÍAif—v‘f‚ª•\‚·ðŒ‚ð’è‹`‚µ‚Ü‚·B
  case—v‘f‚Ìtest‘®«‚Æ“¯—l‚Ì’l‚ð’è‹`‚µ‚Ü‚·B
 -->
-<!ATTLIST if test CDATA #REQUIRED>
+<!ATTLIST if test CDATA #IMPLIED>
 
 <!-- nullCheck‘®«‚ÍAtest‘®«‚ÅAƒvƒƒpƒeƒB•\Œ»‚ÌƒL[‚ðŽw’è‚µ‚½ê‡‚ÉAƒlƒXƒg‚³‚ê‚½ƒvƒƒpƒeƒB‚ªnull‚©‚Ç‚¤‚©‚ðƒ`ƒFƒbƒN‚·‚é‚©‚Ç‚¤‚©‚ðÝ’è‚µ‚Ü‚·B
  case—v‘f‚ÌnullCheck‘®«‚Æ“¯—l‚Ì’l‚ð’è‹`‚µ‚Ü‚·B
@@ -473,6 +474,12 @@ The DOCTYPE is:
  ‚±‚Ì—v‘f‚ÌŽq—v‘f‘S‚Ä‚É“K—p‚³‚ê‚éB
 -->
 <!ATTLIST if journal (true | false) "true">
+
+<!-- test—v‘f‚ÍAðŒ‚ð’è‹`‚µ‚Ü‚·B
+ case—v‘f‚Ìtest‘®«‚Æ“¯—l‚Ì’l‚ð’è‹`‚µ‚Ü‚·B
+ XMLƒGƒXƒP[ƒv‚ðˆÓŽ¯‚µ‚½‚­‚È‚¢ê‡‚ÍAŽq—v‘f‚ÌƒRƒƒ“ƒgƒAƒEƒg“à‚ÉðŒ‚ð‹Lq‚Å‚«‚Ü‚·B
+-->
+<!ELEMENT test (#PCDATA)>
 
 <!-- for—v‘f‚ÍAŒJ‚è•Ô‚µˆ—‚ð’è‹`‚µ‚Ü‚·B
  ŒJ‚è•Ô‚µ‘ÎÛ‚ÌƒIƒuƒWƒFƒNƒg‚ðŽq—v‘f‚Ìtarget—v‘f‚ÅŽw’è‚µ‚Ü‚·B
@@ -525,12 +532,12 @@ The DOCTYPE is:
 <!-- while—v‘f‚ÍAˆê’èðŒ‰º‚Å‚Ìˆ—‚ð’è‹`‚µ‚Ü‚·B
  ‚±‚ÌðŒ‚Éˆê’v‚·‚éê‡‚Ìˆ—‚ðAŽq—v‘f‚É’è‹`‚µ‚Ü‚·B
 -->
-<!ELEMENT while (step* | callflow* | reply* | switch* | if* | for* | while* | break? | continue? | return? | throw?)*>
+<!ELEMENT while (test? | step* | callflow* | reply* | switch* | if* | for* | while* | break? | continue? | return? | throw?)*>
 
 <!-- test‘®«‚ÍAwhile—v‘f‚ª•\‚·ðŒ‚ð’è‹`‚µ‚Ü‚·B
  case—v‘f‚Ìtest‘®«‚Æ“¯—l‚Ì’l‚ð’è‹`‚µ‚Ü‚·B
 -->
-<!ATTLIST while test CDATA #REQUIRED>
+<!ATTLIST while test CDATA #IMPLIED>
 
 <!-- nullCheck‘®«‚ÍAtest‘®«‚ÅAƒvƒƒpƒeƒB•\Œ»‚ÌƒL[‚ðŽw’è‚µ‚½ê‡‚ÉAƒlƒXƒg‚³‚ê‚½ƒvƒƒpƒeƒB‚ªnull‚©‚Ç‚¤‚©‚ðƒ`ƒFƒbƒN‚·‚é‚©‚Ç‚¤‚©‚ðÝ’è‚µ‚Ü‚·B
  case—v‘f‚ÌnullCheck‘®«‚Æ“¯—l‚Ì’l‚ð’è‹`‚µ‚Ü‚·B
@@ -604,12 +611,35 @@ The DOCTYPE is:
 -->
 <!ATTLIST argument narrowCast (true|false) "false">
 
+<!-- input-def—v‘f‚ÍAƒtƒ[‚Ì“ü—Í‚ðŽQÆ‚µ‚Ä–¼‘O’è‹`‚·‚é—v‘f‚Å‚·B
+ ƒtƒ[‚Ì“ü—Í‚ÌƒvƒƒpƒeƒB‚ðA“à—e‚ÉƒvƒƒpƒeƒB–¼‚ðŽw’è‚µ‚ÄŽQÆ‚µ‚Ü‚·B
+ ‚±‚±‚ÅŒ¾‚¤AƒvƒƒpƒeƒB‚ÌŠT”O‚ÍAJava Beans‚ÌƒvƒƒpƒeƒB‚ÌŠT”O‚æ‚èL‚­Ajp.ossc.nimbus.beans.PropertyFactory‚Ì‹K–ñ‚É]‚¢‚Ü‚·B
+ Java Beans‚Ì‚æ‚¤‚È’Pƒ‚ÈƒvƒƒpƒeƒB‚É‰Á‚¦Ajava.util.Map‚È‚Ç‚Ìƒ}ƒbƒvƒvƒƒpƒeƒB‚âjava.util.ListA”z—ñ‚È‚Ç‚ÌƒCƒ“ƒfƒbƒNƒXƒvƒƒpƒeƒBA‚Ü‚½‚»‚ê‚ç‚ªƒlƒXƒg‚µ‚½ƒvƒƒpƒeƒB‚È‚Ç‚àƒTƒ|[ƒg‚µ‚Ü‚·B
+-->
+<!ELEMENT input-def (#PCDATA)>
+
+<!-- name‘®«‚ÍAinput-def—v‘f‚ÅéŒ¾‚·‚é–¼‘O‚ðŽw’è‚µ‚Ü‚·B
+ ‚±‚±‚ÅéŒ¾‚µ‚½–¼‘O‚ÍAinput—v‘f‚Ìname‘®«‚ÅŽw’è‚µ‚ÄA’l‚ðŽQÆ‚Å‚«‚Ü‚·B
+-->
+<!ATTLIST input-def name CDATA #REQUIRED>
+
+<!-- nullCheck‘®«‚ÍAinput-def—v‘f‚Ì“à—e‚ÅAƒvƒƒpƒeƒB•\Œ»‚ðŽw’è‚µ‚½ê‡‚ÉAƒlƒXƒg‚³‚ê‚½ƒvƒƒpƒeƒB‚ªnull‚©‚Ç‚¤‚©‚ðƒ`ƒFƒbƒN‚·‚é‚©‚Ç‚¤‚©‚ðÝ’è‚µ‚Ü‚·B
+ true‚ðÝ’è‚µ‚½ê‡‚ÍAƒlƒXƒg‚³‚ê‚½ƒvƒƒpƒeƒB‚ªnull‚Ìê‡Ajp.ossc.nimbus.beans.NoSuchPropertyException‚ª”­¶‚µ‚Ü‚·B
+ ƒfƒtƒHƒ‹ƒg‚ÍAfalse‚ÅAƒlƒXƒg‚³‚ê‚½ƒvƒƒpƒeƒB‚ªnull‚Ìê‡A‚»‚ÌƒvƒƒpƒeƒB‚Ínull‚Æ‚Ý‚È‚³‚ê‚Ü‚·B
+-->
+<!ATTLIST input-def nullCheck (true | false) "false">
+
 <!-- input—v‘f‚ÍAƒtƒ[‚Ì“ü—Í‚ðŽQÆ‚·‚é—v‘f‚Å‚·B
  ƒtƒ[‚Ì“ü—Í‚ÌƒvƒƒpƒeƒB‚ðŽQÆ‚·‚éê‡‚ÍA“à—e‚ÉƒvƒƒpƒeƒB–¼‚ðŽw’è‚µ‚Ü‚·B
  ‚±‚±‚ÅŒ¾‚¤AƒvƒƒpƒeƒB‚ÌŠT”O‚ÍAJava Beans‚ÌƒvƒƒpƒeƒB‚ÌŠT”O‚æ‚èL‚­Ajp.ossc.nimbus.beans.PropertyFactory‚Ì‹K–ñ‚É]‚¢‚Ü‚·B
  Java Beans‚Ì‚æ‚¤‚È’Pƒ‚ÈƒvƒƒpƒeƒB‚É‰Á‚¦Ajava.util.Map‚È‚Ç‚Ìƒ}ƒbƒvƒvƒƒpƒeƒB‚âjava.util.ListA”z—ñ‚È‚Ç‚ÌƒCƒ“ƒfƒbƒNƒXƒvƒƒpƒeƒBA‚Ü‚½‚»‚ê‚ç‚ªƒlƒXƒg‚µ‚½ƒvƒƒpƒeƒB‚È‚Ç‚àƒTƒ|[ƒg‚µ‚Ü‚·B
 -->
 <!ELEMENT input (#PCDATA)>
+
+<!-- name‘®«‚ÍAinput-def—v‘f‚ÅéŒ¾‚µ‚½–¼‘O‚ðŽw’è‚µ‚Ü‚·B
+ input-def—v‘f‚ÅéŒ¾‚µ‚½name‘®«‚Ì’l‚ðŽw’è‚·‚é‚±‚Æ‚ÅA‚»‚Ì’l‚ðŽQÆ‚Å‚«‚Ü‚·B
+-->
+<!ATTLIST input name CDATA #IMPLIED>
 
 <!-- nullCheck‘®«‚ÍAinput—v‘f‚Ì“à—e‚ÅAƒvƒƒpƒeƒB•\Œ»‚ðŽw’è‚µ‚½ê‡‚ÉAƒlƒXƒg‚³‚ê‚½ƒvƒƒpƒeƒB‚ªnull‚©‚Ç‚¤‚©‚ðƒ`ƒFƒbƒN‚·‚é‚©‚Ç‚¤‚©‚ðÝ’è‚µ‚Ü‚·B
  true‚ðÝ’è‚µ‚½ê‡‚ÍAƒlƒXƒg‚³‚ê‚½ƒvƒƒpƒeƒB‚ªnull‚Ìê‡Ajp.ossc.nimbus.beans.NoSuchPropertyException‚ª”­¶‚µ‚Ü‚·B
@@ -771,6 +801,7 @@ static-invoke—v‘f‚ÌŽq—v‘f‚Éargument—v‘f‚ðŽw’è‚µ‚Ü‚·Bˆø”‚ ‚è‚Ìƒƒ\ƒbƒh‚ðŽÀs‚µ‚
 <!ATTLIST finally journal (true | false) "true">
 
 <!-- expression—v‘f‚ÍAŽ®‚ð•\‚·—v‘f‚Å‚·B
+ XMLƒGƒXƒP[ƒv‚ðˆÓŽ¯‚µ‚½‚­‚È‚¢ê‡‚ÍAŽq—v‘f‚ÌƒRƒƒ“ƒgƒAƒEƒg“à‚ÉŽ®‚ð‹Lq‚Å‚«‚Ü‚·B
  ‚±‚Ì—v‘f‚Ì“à—e‚É‚ÍAŽ®‚ð‹Lq‚·‚éŽ–‚ª‚Å‚«AŽ®’†‚Ì‰Â•Ïƒpƒ‰ƒ[ƒ^‚Æ‚µ‚Ä@‚ÅˆÍ‚ñ‚¾ƒL[‚ðŽw’è‚·‚éŽ–‚ª‚Å‚«‚Ü‚·B
  ƒL[‚Å‚ÍAˆÈ‰º‚Ì‚à‚Ì‚ªŽQÆ‚Å‚«‚Ü‚·B
  (1)ƒXƒeƒbƒv
@@ -778,6 +809,7 @@ static-invoke—v‘f‚ÌŽq—v‘f‚Éargument—v‘f‚ðŽw’è‚µ‚Ü‚·Bˆø”‚ ‚è‚Ìƒƒ\ƒbƒh‚ðŽÀs‚µ‚
    EƒXƒeƒbƒv‚Ì‘ÎÛ : @ƒXƒeƒbƒv–¼.target@
    EƒXƒeƒbƒv‚ÌŒ‹‰Ê : @ƒXƒeƒbƒv–¼.result@ ‚Ü‚½‚Í @ƒXƒeƒbƒv–¼@
    E‚±‚Ì—v‘f‚Ìe—v‘fƒXƒeƒbƒv‚Ì‘ÎÛF@this@
+   EƒXƒeƒbƒvŽ©‘ÌFƒXƒeƒbƒv–¼
   ‚Ü‚½AƒXƒeƒbƒv‚Ì‘ÎÛ‹y‚ÑŒ‹‰Ê‚ÌƒvƒƒpƒeƒB‚ðŽQÆ‚·‚éŽ–‚à‚Å‚«‚Ü‚·B
   ‚»‚Ìê‡‚ÍAã‹L‚Ì•\Œ»‚ÌŒã‚ÉAƒvƒƒpƒeƒB‚ð•\Œ»‚·‚é•¶Žš—ñ‚ðŽw’è‚µ‚Ü‚·B
   ‚±‚±‚ÅŒ¾‚¤AƒvƒƒpƒeƒB‚ÌŠT”O‚ÍAJava Beans‚ÌƒvƒƒpƒeƒB‚ÌŠT”O‚æ‚èL‚­Ajp.ossc.nimbus.beans.PropertyFactory‚Ì‹K–ñ‚É]‚¢‚Ü‚·B
@@ -789,7 +821,7 @@ static-invoke—v‘f‚ÌŽq—v‘f‚Éargument—v‘f‚ðŽw’è‚µ‚Ü‚·Bˆø”‚ ‚è‚Ìƒƒ\ƒbƒh‚ðŽÀs‚µ‚
    ƒXƒeƒbƒv‚ÌŽQÆ‚Æ“¯—l‚Éƒtƒ[‚Ì“ü—Í‚ÌƒvƒƒpƒeƒB‚àŽw’è‚Å‚«‚Ü‚·B
    
  (3)ŒJ‚è•Ô‚µ•Ï”
-   ŒJ‚è•Ô‚µ•Ï”‚ðŽQÆ‚·‚éê‡‚É‚ÍA@var(•Ï”–¼)@‚ÆŽw’è‚µ‚Ü‚·B
+   ŒJ‚è•Ô‚µ•Ï”‚ðŽQÆ‚·‚éê‡‚É‚ÍA@var(•Ï”–¼)@‚ÆŽw’è‚µ‚Ü‚·B‚Ü‚½A•Ï”–¼‚Ì‚Ý‚Å‚àŽQÆ‚Å‚«‚é‚æ‚¤‚É‚È‚è‚Ü‚µ‚½B
    ƒXƒeƒbƒv‚ÌŽQÆ‚Æ“¯—l‚ÉŒJ‚è•Ô‚µ•Ï”‚ÌƒvƒƒpƒeƒB‚àŽw’è‚Å‚«‚Ü‚·B
  
  Ž®‚ÍAThe Apache Jakarta Project‚Ì Commons Jexl(http://jakarta.apache.org/commons/jexl/)‚ðŽg—p‚µ‚Ü‚·B
@@ -805,6 +837,7 @@ static-invoke—v‘f‚ÌŽq—v‘f‚Éargument—v‘f‚ðŽw’è‚µ‚Ü‚·Bˆø”‚ ‚è‚Ìƒƒ\ƒbƒh‚ðŽÀs‚µ‚
 
 <!-- interpreter—v‘f‚ÍƒCƒ“ƒ^[ƒvƒŠƒ^‚ðŽg‚Á‚Äˆ—‚ð•\‚·—v‘f‚Å‚·B
  ‚±‚Ì—v‘f‚Ì“à—e‚É‚ÍAjp.ossc.nimbus.service.interpreter.Interpreter‚ª‰ðŽß‚·‚éƒ\[ƒXƒR[ƒh‚ð‹Lq‚µ‚Ü‚·B
+ XMLƒGƒXƒP[ƒv‚ðˆÓŽ¯‚µ‚½‚­‚È‚¢ê‡‚ÍAŽq—v‘f‚ÌƒRƒƒ“ƒgƒAƒEƒg“à‚Éƒ\[ƒXƒR[ƒh‚ð‹Lq‚Å‚«‚Ü‚·B
  ƒ\[ƒXƒR[ƒh“à‚Å‚ÍAˆÈ‰º‚Ì•Ï”‚ªˆÃ–Ù“I‚ÉŽg—p‰Â”\‚Å‚·B
  (1)ƒXƒeƒbƒv
    ƒXƒeƒbƒv–¼‚ÅŽQÆ‚µ‚Ü‚·B
@@ -815,11 +848,12 @@ static-invoke—v‘f‚ÌŽq—v‘f‚Éargument—v‘f‚ðŽw’è‚µ‚Ü‚·Bˆø”‚ ‚è‚Ìƒƒ\ƒbƒh‚ðŽÀs‚µ‚
  (2)ƒtƒ[‚Ì“ü—Í
    ƒtƒ[‚Ì“ü—Í‚ðŽQÆ‚·‚éê‡‚É‚ÍAinput‚ÆŽw’è‚µ‚Ü‚·B
  (3)ŒJ‚è•Ô‚µ•Ï”
-   ŒJ‚è•Ô‚µ•Ï”‚ðŽQÆ‚·‚éê‡‚É‚ÍAvar.get("•Ï”–¼")‚ÆŽw’è‚µ‚Ü‚·B
+   ŒJ‚è•Ô‚µ•Ï”‚ðŽQÆ‚·‚éê‡‚É‚ÍAvar.get("•Ï”–¼")‚ÆŽw’è‚µ‚Ü‚·B‚Ü‚½A•Ï”–¼‚Ì‚Ý‚Å‚àŽQÆ‚Å‚«‚é‚æ‚¤‚É‚È‚è‚Ü‚µ‚½B
    ’A‚µA•Ï”‚ªéŒ¾‚³‚ê‚Ä‚¢‚È‚¢ê‡‚ÍAvar‚ªnull‚É‚È‚é‚Ì‚ÅA’ˆÓ‚ª•K—v‚Å‚·B
  (4)ƒŠƒ\[ƒX
    ƒŠƒ\[ƒX‚ðŽQÆ‚·‚éê‡‚É‚ÍAresource.getResource("ƒŠƒ\[ƒX–¼")‚ÆŽw’è‚µ‚Ü‚·B
- 
+ (5)ƒWƒƒ[ƒiƒ‹
+   ƒWƒƒ[ƒiƒ‹‚ðo—Í‚·‚éê‡‚É‚ÍAjournal‚ÅAJournalƒIƒuƒWƒFƒNƒg‚ðŽQÆ‚Å‚«‚Ü‚·B
  ƒ\[ƒXƒR[ƒh“à‚Å–ß‚è’l‚ð•Ô‚·‚ÆA‚±‚ÌƒXƒeƒbƒv‚Ìresult‚É‚È‚è‚Ü‚·B
  ’A‚µAresult—v‘f‚ð‹Lq‚µ‚½ê‡‚ÍA‚»‚¿‚ç‚ª—Dæ‚³‚ê‚Ü‚·B
  BeanFlowInvokerFactoryƒT[ƒrƒX‚ÉŽg—p‚·‚éjp.ossc.nimbus.service.interpreter.Interpreter‚ðÝ’è‚µ‚Ä‚¨‚­•K—v‚ª‚ ‚è‚Ü‚·B


### PR DESCRIPTION
Nimbus2のBeanFlowの機能を取り込んで、BeanFlow3を作ろうかと思ったんだけど、差分が以外と多くなかったので、BeanFlow2にマージしました。

ついでに、生産性向上のために、いくつか機能追加をしてみました。

- input-def要素を追加した。←Nimbus2からの取り込み
- input要素にname属性を追加した。←Nimbus2からの取り込み
- if、case、while要素配下に、test要素を追加した。
- expression、interpreter要素下に内容をコメントで記述できるようにした。
- interpreter要素の内容で、journalを使用できるようにした。

動作確認して、マージしてください。