### PR TITLE
DistributedSharedContextServiceの、不要なsynchronizedメソッドをunsynchronizedにした

### DIFF
--- a/src/main/java/jp/ossc/nimbus/service/context/DistributedSharedContextService.java
+++ b/src/main/java/jp/ossc/nimbus/service/context/DistributedSharedContextService.java
@@ -1148,7 +1148,7 @@ public class DistributedSharedContextService extends ServiceBase implements Dist
         putAll(t, defaultTimeout);
     }
     
-    public synchronized void putAll(Map t, long timeout) throws SharedContextSendException, SharedContextTimeoutException{
+    public void putAll(Map t, long timeout) throws SharedContextSendException, SharedContextTimeoutException{
         final long start = System.currentTimeMillis();
         Map distMap = new HashMap();
         Iterator entries = t.entrySet().iterator();
@@ -1218,7 +1218,7 @@ public class DistributedSharedContextService extends ServiceBase implements Dist
         }
     }
     
-    public synchronized void putAllLocal(Map t){
+    public void putAllLocal(Map t){
         Iterator entries = t.entrySet().iterator();
         while(entries.hasNext()){
             Map.Entry entry = (Map.Entry)entries.next();
@@ -1226,7 +1226,7 @@ public class DistributedSharedContextService extends ServiceBase implements Dist
         }
     }
     
-    public synchronized void putAllAsynch(Map t) throws SharedContextSendException{
+    public void putAllAsynch(Map t) throws SharedContextSendException{
         Iterator entries = t.entrySet().iterator();
         Map distMap = new HashMap();
         while(entries.hasNext()){
@@ -1286,7 +1286,7 @@ public class DistributedSharedContextService extends ServiceBase implements Dist
         clear(defaultTimeout <= 0 ? 0 : defaultTimeout * sharedContextArray.length);
     }
     
-    public synchronized void clear(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
+    public void clear(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
         if(parallelRequestQueueHandlerContainer == null){
             for(int i = 0; i < sharedContextArray.length; i++){
                 long start = System.currentTimeMillis();
@@ -1334,13 +1334,13 @@ public class DistributedSharedContextService extends ServiceBase implements Dist
         }
     }
     
-    public synchronized void clearLocal(){
+    public void clearLocal(){
         for(int i = 0; i < sharedContextArray.length; i++){
             sharedContextArray[i].clearLocal();
         }
     }
     
-    public synchronized void clearAsynch() throws SharedContextSendException{
+    public void clearAsynch() throws SharedContextSendException{
         if(parallelRequestQueueHandlerContainer == null){
             for(int i = 0; i < sharedContextArray.length; i++){
                 sharedContextArray[i].clearAsynch();
@@ -1528,7 +1528,7 @@ public class DistributedSharedContextService extends ServiceBase implements Dist
         return keySet(defaultTimeout <= 0 ? 0 : defaultTimeout * sharedContextArray.length);
     }
     
-    public synchronized Set keySet(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
+    public Set keySet(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
         Set result = new HashSet();
         if(parallelRequestQueueHandlerContainer == null){
             for(int i = 0; i < sharedContextArray.length; i++){
@@ -1579,7 +1579,7 @@ public class DistributedSharedContextService extends ServiceBase implements Dist
         return result;
     }
     
-    public synchronized Set keySetLocal(){
+    public Set keySetLocal(){
         Set result = new HashSet();
         for(int i = 0; i < sharedContextArray.length; i++){
             result.addAll(sharedContextArray[i].keySetLocal());
@@ -1591,7 +1591,7 @@ public class DistributedSharedContextService extends ServiceBase implements Dist
         return size(defaultTimeout <= 0 ? 0 : defaultTimeout * sharedContextArray.length);
     }
     
-    public synchronized int size(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
+    public int size(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
         int result = 0;
         if(parallelRequestQueueHandlerContainer == null){
             for(int i = 0; i < sharedContextArray.length; i++){
@@ -1642,7 +1642,7 @@ public class DistributedSharedContextService extends ServiceBase implements Dist
         return result;
     }
     
-    public synchronized int sizeLocal(){
+    public int sizeLocal(){
         int result = 0;
         for(int i = 0; i < sharedContextArray.length; i++){
             result += sharedContextArray[i].sizeLocal();

--- a/src/main/java/jp/ossc/nimbus/service/context/SharedContextService.java
+++ b/src/main/java/jp/ossc/nimbus/service/context/SharedContextService.java
@@ -2046,7 +2046,7 @@ public class SharedContextService extends DefaultContextService
         putAll(t, defaultTimeout);
     }
     
-    public synchronized void putAll(Map t, long timeout) throws SharedContextSendException, SharedContextTimeoutException{
+    public void putAll(Map t, long timeout) throws SharedContextSendException, SharedContextTimeoutException{
         if(t.size() == 0){
             return;
         }
@@ -2151,7 +2151,7 @@ public class SharedContextService extends DefaultContextService
         }
     }
     
-    public synchronized void putAllLocal(Map t){
+    public void putAllLocal(Map t){
         if(t.size() == 0){
             return;
         }
@@ -2211,7 +2211,7 @@ public class SharedContextService extends DefaultContextService
         }
     }
     
-    public synchronized void putAllAsynch(Map t) throws SharedContextSendException{
+    public void putAllAsynch(Map t) throws SharedContextSendException{
         if(t.size() == 0){
             return;
         }
@@ -2308,7 +2308,7 @@ public class SharedContextService extends DefaultContextService
         clear(defaultTimeout);
     }
     
-    public synchronized void clear(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
+    public void clear(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
         if(isMain() && size() == 0){
             return;
         }
@@ -2392,7 +2392,7 @@ public class SharedContextService extends DefaultContextService
         }
     }
     
-    public synchronized void clearLocal(){
+    public void clearLocal(){
         if(size() == 0){
             return;
         }
@@ -2431,7 +2431,7 @@ public class SharedContextService extends DefaultContextService
         }
     }
     
-    public synchronized void clearAsynch() throws SharedContextSendException{
+    public void clearAsynch() throws SharedContextSendException{
         if(isMain() && size() == 0){
             return;
         }
@@ -2636,7 +2636,7 @@ public class SharedContextService extends DefaultContextService
         return keySet(defaultTimeout);
     }
     
-    public synchronized Set keySet(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
+    public Set keySet(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
         try{
             long startTime = System.currentTimeMillis();
             if(!referLock.acquireForUse(timeout)){
@@ -2682,7 +2682,7 @@ public class SharedContextService extends DefaultContextService
         }
     }
     
-    public synchronized Set keySetLocal(){
+    public Set keySetLocal(){
         try{
             referLock.acquireForUse(-1);
             return super.keySet();
@@ -2695,7 +2695,7 @@ public class SharedContextService extends DefaultContextService
         return size(defaultTimeout);
     }
     
-    public synchronized int size(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
+    public int size(long timeout) throws SharedContextSendException, SharedContextTimeoutException{
         try{
             long startTime = System.currentTimeMillis();
             if(!referLock.acquireForUse(timeout)){
@@ -2741,7 +2741,7 @@ public class SharedContextService extends DefaultContextService
         }
     }
     
-    public synchronized int sizeLocal(){
+    public int sizeLocal(){
         try{
             referLock.acquireForUse(-1);
             return super.size();


### PR DESCRIPTION
修正不十分。
DistributedSharedContextServiceの先のSharedContextServiceもsynchronizedだった。