### PR TITLE
BeanFlowでデフォルトのトランザクションタイムアウトを設定できるようにした。

### DIFF
--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerAccessImpl2.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerAccessImpl2.java
@@ -821,16 +821,20 @@ public class BeanFlowInvokerAccessImpl2 extends MetaData implements BeanFlowInvo
     ) throws Exception {
         ((BeanFlowMonitorImpl)monitor).setStartTime(System.currentTimeMillis());
         try{
+            Integer defaultTransactionTimeout = factoryCallBack.getDefaultTransactionTimeout();
             Object result = null;
             Transaction oldTransaction
                 = tranManager == null ? null : tranManager.getTransaction();
             Transaction newTransaction = null;
             switch(transactionType){
             case REQUIRED_VALUE:
-                if(transactionTimeout != -1 && oldTransaction == null){
-                    tranManager.setTransactionTimeout(transactionTimeout);
-                }
+                
                 if(oldTransaction == null){
+                    if(transactionTimeout != -1){
+                        tranManager.setTransactionTimeout(transactionTimeout);
+                    }else if(defaultTransactionTimeout != null){
+                        tranManager.setTransactionTimeout(defaultTransactionTimeout.intValue());
+                    }
                     tranManager.begin();
                     newTransaction = tranManager.getTransaction();
                 }
@@ -856,6 +860,8 @@ public class BeanFlowInvokerAccessImpl2 extends MetaData implements BeanFlowInvo
                 try{
                     if(transactionTimeout != -1){
                         tranManager.setTransactionTimeout(transactionTimeout);
+                    }else if(defaultTransactionTimeout != null){
+                        tranManager.setTransactionTimeout(defaultTransactionTimeout.intValue());
                     }
                     tranManager.begin();
                     newTransaction = tranManager.getTransaction();

--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerFactoryCallBack.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerFactoryCallBack.java
@@ -111,4 +111,6 @@ public interface BeanFlowInvokerFactoryCallBack {
     
     public QueueHandlerContainer getAsynchInvokeQueueHandlerContainer();
     public String replaceProperty(String textValue);
+    
+    public Integer getDefaultTransactionTimeout();
 }

--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/DefaultBeanFlowInvokerFactoryService.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/DefaultBeanFlowInvokerFactoryService.java
@@ -195,6 +195,8 @@ public class DefaultBeanFlowInvokerFactoryService extends ServiceBase
     private boolean isOutputJournalMetricsAverageSize = true;
     private boolean isOutputJournalMetricsTimestamp = false;
     private Map journalMetricsInfos;
+    
+    private Integer defaultTransactionTimeout;
 
     // DefaultBeanFlowInvokerFactoryServiceMBeanのJavaDoc
     public void setValidate(boolean validate){
@@ -470,6 +472,16 @@ public class DefaultBeanFlowInvokerFactoryService extends ServiceBase
     // DefaultBeanFlowInvokerFactoryServiceMBeanのJavaDoc
     public boolean isOutputJournalMetricsTimestamp(){
         return isOutputJournalMetricsTimestamp;
+    }
+    
+    // DefaultBeanFlowInvokerFactoryServiceMBeanのJavaDoc
+    public void setDefaultTransactionTimeout(Integer timeout){
+        defaultTransactionTimeout = timeout;
+    }
+    
+    // DefaultBeanFlowInvokerFactoryServiceMBeanのJavaDoc
+    public Integer getDefaultTransactionTimeout(){
+        return defaultTransactionTimeout;
     }
     
     // DefaultBeanFlowInvokerFactoryServiceMBeanのJavaDoc

--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/DefaultBeanFlowInvokerFactoryServiceMBean.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/DefaultBeanFlowInvokerFactoryServiceMBean.java
@@ -468,6 +468,22 @@ public interface DefaultBeanFlowInvokerFactoryServiceMBean
     public boolean isOutputJournalMetricsTimestamp();
     
     /**
+     * JTAを使用する場合の、デフォルトのトランザクションタイムアウト[s]を設定する。<p>
+     * デフォルトは、nullで、タイムアウトを設定しない。<br>
+     *
+     * @param timeout デフォルトのトランザクションタイムアウト[s]
+     */
+    public void setDefaultTransactionTimeout(Integer timeout);
+    
+    /**
+     * JTAを使用する場合の、デフォルトのトランザクションタイムアウト[s]を取得する。<p>
+     *
+     * @return デフォルトのトランザクションタイムアウト[s]
+     */
+    public Integer getDefaultTransactionTimeout();
+    
+    
+    /**
      * ジャーナルの出力サイズの統計情報を初期化する。<p>
      */
     public void resetJournalMetrics();


### PR DESCRIPTION
マージしてください。
・BeanFlowでデフォルトのトランザクションタイムアウトを設定できるようにした。