### PR TITLE
jp.ossc.nimbus.service.publish.udp.ConnectionFactoryServiceをマルチキャストで送…

### DIFF
--- a/src/main/java/jp/ossc/nimbus/service/publish/ClusterClientConnectionImpl.java
+++ b/src/main/java/jp/ossc/nimbus/service/publish/ClusterClientConnectionImpl.java
@@ -85,12 +85,14 @@ public class ClusterClientConnectionImpl implements ClientConnection, ClusterLis
     private transient boolean isStartReceive;
     private transient long fromTime;
     private transient long lastReceiveTime = -1;
+    private String clientNo;
     
     public ClusterClientConnectionImpl(){
     }
     
-    public ClusterClientConnectionImpl(ClusterService cluster){
+    public ClusterClientConnectionImpl(ClusterService cluster, String no){
         setCluster(cluster);
+        clientNo = no;
     }
     
     public void setCluster(ClusterService cluster){
@@ -165,7 +167,7 @@ public class ClusterClientConnectionImpl implements ClientConnection, ClusterLis
                     cluster.setClient(true);
                     cluster.addClusterListener(this);
                     cluster.start();
-                    this.id = id == null ? uid : id;
+                    this.id = id == null ? (uid + clientNo) : id;
                     cluster.join();
                 }catch(Exception e){
                     cluster.stop();
@@ -173,7 +175,7 @@ public class ClusterClientConnectionImpl implements ClientConnection, ClusterLis
                     throw new ConnectException(e);
                 }
             }else{
-                this.id = id == null ? uid : id;
+                this.id = id == null ? (uid + clientNo) : id;
                 cluster.addClusterListener(this);
             }
             if(!isFlexibleConnect && (connectionMap == null || connectionMap.size() == 0)){

--- a/src/main/java/jp/ossc/nimbus/service/publish/ClusterConnectionFactoryServiceMBean.java
+++ b/src/main/java/jp/ossc/nimbus/service/publish/ClusterConnectionFactoryServiceMBean.java
@@ -149,6 +149,20 @@ public interface ClusterConnectionFactoryServiceMBean extends ServiceBaseMBean{
     public ServiceName getClientConnectionFactoryServiceName();
     
     /**
+     * {@link jp.ossc.nimbus.service.publish.ClientConnection ClientConnection}のIDを生成する{@link jp.ossc.nimbus.service.sequence.Sequence Sequence}サービスのサービス名を設定する。<p>
+     * 
+     * @param name Sequenceサービスのサービス名
+     */
+    public void setSequenceServiceName(ServiceName name);
+    
+    /**
+     * {@link jp.ossc.nimbus.service.publish.ClientConnection ClientConnection}のIDを生成する{@link jp.ossc.nimbus.service.sequence.Sequence Sequence}サービスのサービス名を取得する。<p>
+     * 
+     * @return Sequenceサービスのサービス名
+     */
+    public ServiceName getSequenceServiceName();
+    
+    /**
      * 分散クラスタにするかどうかを設定する。<p>
      * trueにすると分散クラスタとなり、クライアントは、接続台数の少ないクラスタメンバに接続し、サーバに対して分散して接続する。<br>
      * デフォルトはfalseで、全てのクライアントが主系となっているクラスタメンバに接続する。<br>


### PR DESCRIPTION
…受信するように設定したうえで、jp.ossc.nimbus.service.publish.ClusterConnectionFactoryServiceにクラスタ化する。

それを受信側のサーバで、jp.ossc.nimbus.service.publish.ClusterClientConnectionFactoryServiceを使って、ClientConnectionを複数つなぐと、各Connectionに同じIDが振られてしまい、メッセージを重複して受信してしまう問題を修正した。