### PR TITLE
プロパティの型指定がない場合は、getType()でObject.classを返すように変更した。

### DIFF
--- a/src/main/java/jp/ossc/nimbus/beans/dataset/DefaultPropertySchema.java
+++ b/src/main/java/jp/ossc/nimbus/beans/dataset/DefaultPropertySchema.java
@@ -587,7 +587,7 @@ public class DefaultPropertySchema implements PropertySchema, Serializable{
     
     // PropertySchemaのJavaDoc
     public Class getType(){
-        return type;
+        return type == null ? Object.class : type;
     }
     
     public boolean isPrimaryKey(){


### PR DESCRIPTION
マージしてください。