### PR TITLE
#186の修正

### DIFF
--- a/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerAccessImpl2.java
+++ b/src/main/java/jp/ossc/nimbus/service/beancontrol/BeanFlowInvokerAccessImpl2.java
@@ -4249,8 +4249,13 @@ public class BeanFlowInvokerAccessImpl2 extends MetaData implements BeanFlowInvo
         }
 
         public void importXML(Element element) throws DeploymentException{
-            name = getUniqueAttribute(element, NAME_ATTRIBUTE);
+            name = getOptionalAttribute(element, NAME_ATTRIBUTE);
             stepName = getOptionalAttribute(element, STEPNAME_ATTRIBUTE, name);
+            if(stepName == null){
+                throw new DeploymentException(
+                    "it is necessary to specify \"" + NAME_ATTRIBUTE + "\" or  \"" + STEPNAME_ATTRIBUTE + "\" of <" + REPLY_ELEMENT + '>'
+                );
+            }
             coverage.setElementName("<" + REPLY_ELEMENT + " " + STEPNAME_ATTRIBUTE + "=\"" + stepName + "\">");
 
             final String journalStr = MetaData.getOptionalAttribute(
@@ -4337,8 +4342,17 @@ public class BeanFlowInvokerAccessImpl2 extends MetaData implements BeanFlowInvo
                                 }
                             }
                             stepContext.result = asynchContext.getBeanFlowInvoker().getAsynchReply(asynchContext, context.monitor, timeoutVal, isCancel);
+                            if(asynchContexts.size() != 0 && name != null && name.equals(stepName)){
+                                throw new DeploymentException(
+                                    "\"" + NAME_ATTRIBUTE + "\" and \"" + STEPNAME_ATTRIBUTE + "\" are the same. Explicitly \"" + STEPNAME_ATTRIBUTE + "\" is not specified or the same value as \"" + NAME_ATTRIBUTE + "\" is specified. " + NAME_ATTRIBUTE + "=" + name
+                                );
+                            }
                         }
                     }
+                }else{
+                    throw new DeploymentException(
+                        "The specified \"" + STEPNAME_ATTRIBUTE + "\" is not <" + CALL_FLOW_ELEMENT + ">. " + STEPNAME_ATTRIBUTE + "=" + stepName
+                    );
                 }
                 if(journal != null){
                     journal.addInfo(
@@ -4377,7 +4391,9 @@ public class BeanFlowInvokerAccessImpl2 extends MetaData implements BeanFlowInvo
                 if(!isCatch){
                     throwException(th);
                 }
-                context.put(name, stepContext);
+                if(name != null){
+                    context.put(name, stepContext);
+                }
             }finally{
                 try{
                     if(finallyStep != null){
@@ -4391,7 +4407,9 @@ public class BeanFlowInvokerAccessImpl2 extends MetaData implements BeanFlowInvo
                     }
                 }
             }
-            context.put(name, stepContext);
+            if(name != null){
+                context.put(name, stepContext);
+            }
             return stepContext;
         }
     }

--- a/src/main/resources/jp/ossc/nimbus/service/beancontrol/beanflow_1_0.dtd
+++ b/src/main/resources/jp/ossc/nimbus/service/beancontrol/beanflow_1_0.dtd
@@ -374,7 +374,7 @@ The DOCTYPE is:
 
 <!-- name属性は、reply要素のステップ名を定義します。
 -->
-<!ATTLIST reply name CDATA #REQUIRED>
+<!ATTLIST reply name CDATA #IMPLIED>
 
 <!-- stepname属性は、reply要素で取得する非同期子フロー呼び出しであるcallflow要素のステップ名を定義します。
  定義しない場合は、name属性で指定したステップ名がそのままcallflow要素のステップ名になります。


### PR DESCRIPTION
・reply要素のname属性を必須からオプションに変更。
・reply要素のname属性のみを指定している場合、またはstepname属性とname属性に同じ値が指定されている場合は、実行時に、複数回のreplyが可能な場合は、例外を発生させるようにした。
・reply要素で指定されたstepname（stepname属性を省略した場合のnameも含む）で指定したものが、callflow要素ではない場合は、例外をthrowするようにした。