### PR TITLE
性能対策

### DIFF
--- a/src/main/java/jp/ossc/nimbus/service/publish/DistributedClientConnectionImpl.java
+++ b/src/main/java/jp/ossc/nimbus/service/publish/DistributedClientConnectionImpl.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.io.Serializable;
 import java.net.UnknownHostException;
+import java.net.InetAddress;
 
 import jp.ossc.nimbus.service.queue.AsynchContext;
 import jp.ossc.nimbus.service.queue.DefaultQueueService;
@@ -75,7 +76,7 @@ public class DistributedClientConnectionImpl implements ClientConnection, Serial
         Object tmpId = null;
         if(id == null){
             try{
-                tmpId = new GlobalUID();
+                tmpId = new GlobalUID(InetAddress.getLocalHost());
             }catch(UnknownHostException e){
                 throw new ConnectException(e);
             }

--- a/src/main/java/jp/ossc/nimbus/service/publish/GroupClientConnectionImpl.java
+++ b/src/main/java/jp/ossc/nimbus/service/publish/GroupClientConnectionImpl.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.regex.Pattern;
 import java.io.Serializable;
+import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import jp.ossc.nimbus.util.net.GlobalUID;
@@ -86,7 +87,7 @@ public class GroupClientConnectionImpl implements ClientConnection, Serializable
     public void connect(Object id) throws ConnectException{
         if(id == null){
             try{
-                this.id = new GlobalUID();
+                this.id = new GlobalUID(InetAddress.getLocalHost());
             }catch(UnknownHostException e){
                 throw new ConnectException(e);
             }

--- a/src/main/java/jp/ossc/nimbus/util/net/GlobalUID.java
+++ b/src/main/java/jp/ossc/nimbus/util/net/GlobalUID.java
@@ -45,8 +45,7 @@ public class GlobalUID implements Externalizable, Comparable, Cloneable{
     protected UID uid;
     protected InetAddress address;
     
-    public GlobalUID() throws UnknownHostException{
-        this((InetAddress)null);
+    public GlobalUID(){
     }
     
     public GlobalUID(String localAddress) throws UnknownHostException{


### PR DESCRIPTION
・引数なしのコンストラクタで、ローカルホスト用のUIDを生成する仕様だったのを、空のインスタンスを生成するように変更した。
・引数なしのコンストラクタを使用していた箇所を、引数ありのコンストラクタを使用するように修正した。