### PR TITLE
#241対応

### DIFF
--- a/src/main/java/jp/ossc/nimbus/service/publish/ClusterClientConnectionFactoryService.java
+++ b/src/main/java/jp/ossc/nimbus/service/publish/ClusterClientConnectionFactoryService.java
@@ -143,7 +143,7 @@ public class ClusterClientConnectionFactoryService extends ServiceBase
         public void connect(Object id) throws ConnectException{
             if(connection == null){
                 List members = cluster.getMembers();
-                ClusterService.GlobalUID uid = members.size() == 0 ? null : (ClusterService.GlobalUID)members.get(0);
+                ClusterService.GlobalUID uid = !cluster.isJoin() || members.size() == 0 ? null : (ClusterService.GlobalUID)members.get(0);
                 if(uid == null){
                     if(!isFlexibleConnect){
                         throw new ConnectException("No cluster member.");


### PR DESCRIPTION
clusterにjoinしていない場合で、isFlexibleConnect=trueの場合は、例外が発生しないように修正した。