### PR TITLE
ストア先のキャッシュに退避して、リンクする前に、元のキャッシュ参照をnullにしているために、一時的にキャッシュがnullになる不具合を修…

### DIFF
--- a/src/main/java/jp/ossc/nimbus/service/cache/StoreCacheOverflowActionService.java
+++ b/src/main/java/jp/ossc/nimbus/service/cache/StoreCacheOverflowActionService.java
@@ -234,11 +234,11 @@ public class StoreCacheOverflowActionService extends ServiceBase
             }
             if(newRef != null){
                 try{
-                    ref.set(this, null);
+                    references.put(ref, newRef);
                     ref.addLinkedReference(this);
                     ref.addCacheRemoveListener(this);
                     ref.addCacheChangeListener(this);
-                    references.put(ref, newRef);
+                    ref.set(this, null);
                     if(validator != null){
                         validator.remove(ref);
                     }


### PR DESCRIPTION
…正した。