### PR TITLE
Issue #597対応

### DIFF
--- a/src/main/java/jp/ossc/nimbus/service/context/SharedContextIndex.java
+++ b/src/main/java/jp/ossc/nimbus/service/context/SharedContextIndex.java
@@ -154,7 +154,14 @@ public class SharedContextIndex implements Externalizable, Cloneable{
     }
     
     public void remove(Object key, Object value) throws IndexPropertyAccessException{
-        if(value instanceof List){
+        if(value == null){
+            nullKeySet.remove(key);
+            Iterator itr = indexKeyMap.values().iterator();
+            while(itr.hasNext()){
+                ConcurrentHashMap keys = (ConcurrentHashMap)itr.next();
+                keys.remove(key);
+            }
+        }else if(value instanceof List){
             List list = (List)value;
             Set keySet = null;
             for(int i = 0, imax = list.size(); i < imax; i++){

--- a/src/main/java/jp/ossc/nimbus/service/queue/QueueHandlerContainerService.java
+++ b/src/main/java/jp/ossc/nimbus/service/queue/QueueHandlerContainerService.java
@@ -521,7 +521,6 @@ public class QueueHandlerContainerService extends ServiceBase
         }
         isSuspend = false;
         if(getQueueService() == null){
-            suspendMonitor.notifyAllMonitor();
             suspendMonitor.releaseAllMonitor();
         }else{
             if(daemons != null){

--- a/src/main/java/jp/ossc/nimbus/util/SleepSynchronizeMonitor.java
+++ b/src/main/java/jp/ossc/nimbus/util/SleepSynchronizeMonitor.java
@@ -193,7 +193,7 @@ public class SleepSynchronizeMonitor implements SynchronizeMonitor, java.io.Seri
         }
         try{
             long waitTime = timeout;
-            while(!monitorFlag.isNotify){
+            while(monitorFlagMap.containsKey(currentThread) && !monitorFlag.isNotify){
                 if(timeout > 0){
                     if(waitTime >= 0){
                         try{
@@ -230,7 +230,7 @@ public class SleepSynchronizeMonitor implements SynchronizeMonitor, java.io.Seri
         synchronized(monitorFlag){
             boolean isNotify = monitorFlag.isNotify;
             monitorFlag.isNotify = false;
-            return isNotify;
+            return isNotify && monitorFlagMap.containsKey(currentThread);
         }
     }
     
@@ -396,7 +396,7 @@ public class SleepSynchronizeMonitor implements SynchronizeMonitor, java.io.Seri
     
     public void close(){
         isClosed = true;
-        notifyAllMonitor();
+        releaseAllMonitor();
     }
     
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException{

--- a/src/main/java/jp/ossc/nimbus/util/WaitSynchronizeMonitor.java
+++ b/src/main/java/jp/ossc/nimbus/util/WaitSynchronizeMonitor.java
@@ -99,6 +99,7 @@ public class WaitSynchronizeMonitor implements SynchronizeMonitor, java.io.Seria
     public synchronized void releaseMonitor(){
         final Thread currentThread = Thread.currentThread();
         monitorFlagMap.remove(currentThread);
+        notifyAll();
     }
     
     /**
@@ -106,6 +107,7 @@ public class WaitSynchronizeMonitor implements SynchronizeMonitor, java.io.Seria
      */
     public synchronized void releaseAllMonitor(){
         monitorFlagMap.clear();
+        notifyAll();
     }
     
     /**
@@ -162,7 +164,7 @@ public class WaitSynchronizeMonitor implements SynchronizeMonitor, java.io.Seria
         monitorFlag.isWait = true;
         try{
             long waitTime = timeout;
-            while(!monitorFlag.isNotify){
+            while(monitorFlagMap.containsKey(currentThread) && !monitorFlag.isNotify){
                 if(timeout > 0){
                     if(waitTime >= 0){
                         wait(waitTime);
@@ -183,7 +185,7 @@ public class WaitSynchronizeMonitor implements SynchronizeMonitor, java.io.Seria
         }
         boolean isNotify = monitorFlag.isNotify;
         monitorFlag.isNotify = false;
-        return isNotify;
+        return isNotify && monitorFlagMap.containsKey(currentThread);
     }
     
     /**
@@ -296,7 +298,7 @@ public class WaitSynchronizeMonitor implements SynchronizeMonitor, java.io.Seria
     
     public synchronized void close(){
         isClosed = true;
-        notifyAllMonitor();
+        releaseAllMonitor();
     }
     
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException{


### PR DESCRIPTION
・TCP/UDP通信のsynchronizedロックと、通信待ちの組み合わせによるデッドロックを回避するように修正
・TCP/UDP通信の切断時に、通信待ちに入らないようにするのと、通信待ちになった場合に、待ちを中断するように修正
・TCP/UDP通信で、サーバ側から切断された場合に、切断のログが２種類出力されるのを１種類にした。また、EOFでの切断も正常切断とみなすようにした。
・UDPユニキャスト通信の際に、最初の電文の処理がうまく行かない場合がある不具合を修正した。
・TCP/UDP通信で、ACKを返すタイミングを、ServerConnectionListenerへの通知の前に変更した。
・ClusterClientConnectionの、synchronizedロックを減らして、Clusterメンバの変更と、サブジェクトの登録削除の処理とデッドロックにならないようにした。
・ノードが参加されたタイミングで、メインノードがrehashを行うようにした。
・MessageReceiverに、サブジェクトとMessageListernerを登録するときに、サーバへの要求の直前に、自分の管理してるサブジェクトを先に変更するようにした。
・SynchronizedMonitorのreleaseAllMonitor()の内部処理でnotifyするように変更した。
・RequestConnectionで、送信の応答待ちと、Connectionの切断が行き違いになり、切断されたConnectionの応答を待ってしまう不具合を修正した。
・SharedContextIndexのremove(key,
value)で、valueがnullの場合、インデックスから無条件にkeyを削除するようにした。
・SharedContextのインデックスの更新処理を見直した。
・スプリットブレインした際に、メインノードが同期要求を受けて、再帰処理にならないようにした。
・SharedContextViewのサーバサイドインデックスを使った場合に、searchFrom、searchTo、searchRange等のいくつかの処理が動作しない不具合を修正した。