### PR TITLE
Issue #633対応

### DIFF
--- a/src/main/java/jp/ossc/nimbus/io/RecurciveSearchFile.java
+++ b/src/main/java/jp/ossc/nimbus/io/RecurciveSearchFile.java
@@ -794,6 +794,9 @@ public class RecurciveSearchFile extends File implements Serializable {
     
     public static void dataCopy(File fromFile, File toFile) throws IOException {
         FileInputStream fis = new FileInputStream(fromFile);
+        if(toFile.getParentFile() != null && !toFile.getParentFile().exists()){
+            toFile.getParentFile().mkdirs();
+        }
         FileOutputStream fos = new FileOutputStream(toFile);
         try {
             byte[] buf = new byte[1024];

--- a/src/main/java/jp/ossc/nimbus/service/test/HttpTestControllerClientService.java
+++ b/src/main/java/jp/ossc/nimbus/service/test/HttpTestControllerClientService.java
@@ -737,16 +737,16 @@ public class HttpTestControllerClientService extends ServiceBase implements Test
     }
     
     public void generateTestScenarioGroupEvidenceFile(String scenarioGroupId) throws Exception {
-        File targetDir = new File(testResourceFileBaseDirectory, scenarioGroupId);
-        if (!targetDir.exists()) {
-            return;
-        }
         if (isUploadEvidenceServer) {
             Map params = new HashMap();
             params.put("scenarioGroupId", scenarioGroupId);
             request("generateTestScenarioGroupEvidenceFile", params);
         }
         if (testResourceManager != null && testResourceManager instanceof UploadableTestResourceManager) {
+            File targetDir = new File(testResourceFileBaseDirectory, scenarioGroupId);
+            if (!targetDir.exists()) {
+                return;
+            }
             TestScenarioGroupResource testScenarioGroupResource = getTestScenarioGroupResource(scenarioGroupId);
             if (testScenarioGroupResource != null) {
                 Map actionEvidenceFileNameMap = testScenarioGroupResource.getActionEvidenceFileNameMap();
@@ -774,10 +774,6 @@ public class HttpTestControllerClientService extends ServiceBase implements Test
     }
     
     public void generateTestScenarioEvidenceFile(String scenarioGroupId, String scenarioId) throws Exception {
-        File targetDir = new File(testResourceFileBaseDirectory, scenarioGroupId + File.separator + scenarioId);
-        if (!targetDir.exists()) {
-            return;
-        }
         if (isUploadEvidenceServer) {
             Map params = new HashMap();
             params.put("scenarioGroupId", scenarioGroupId);
@@ -785,6 +781,10 @@ public class HttpTestControllerClientService extends ServiceBase implements Test
             request("generateTestScenarioEvidenceFile", params);
         }
         if (testResourceManager != null && testResourceManager instanceof UploadableTestResourceManager) {
+            File targetDir = new File(testResourceFileBaseDirectory, scenarioGroupId + File.separator + scenarioId);
+            if (!targetDir.exists()) {
+                return;
+            }
             TestScenarioResource testScenarioResource = getTestScenarioResource(scenarioGroupId, scenarioId);
             if (testScenarioResource != null) {
                 Map actionEvidenceFileNameMap = testScenarioResource.getActionEvidenceFileNameMap();
@@ -812,10 +812,6 @@ public class HttpTestControllerClientService extends ServiceBase implements Test
     }
     
     public void generateTestCaseEvidenceFile(String scenarioGroupId, String scenarioId, String testcaseId) throws Exception {
-        File targetDir = new File(testResourceFileBaseDirectory, scenarioGroupId + File.separator + scenarioId + File.separator + testcaseId);
-        if (!targetDir.exists()) {
-            return;
-        }
         if (isUploadEvidenceServer) {
             Map params = new HashMap();
             params.put("scenarioGroupId", scenarioGroupId);
@@ -824,6 +820,10 @@ public class HttpTestControllerClientService extends ServiceBase implements Test
             request("generateTestCaseEvidenceFile", params);
         }
         if (testResourceManager != null && testResourceManager instanceof UploadableTestResourceManager) {
+            File targetDir = new File(testResourceFileBaseDirectory, scenarioGroupId + File.separator + scenarioId + File.separator + testcaseId);
+            if (!targetDir.exists()) {
+                return;
+            }
             TestCaseResource testCaseResource = getTestCaseResource(scenarioGroupId, scenarioId, testcaseId);
             if (testCaseResource != null) {
                 Map actionEvidenceFileNameMap = testCaseResource.getActionEvidenceFileNameMap();

--- a/src/main/java/jp/ossc/nimbus/service/test/HttpTestControllerServerService.java
+++ b/src/main/java/jp/ossc/nimbus/service/test/HttpTestControllerServerService.java
@@ -1033,79 +1033,80 @@ public class HttpTestControllerServerService extends HttpProcessServiceBase impl
                 }
             }
         } else if (request.getHeader().getURLMatcher(".*generateTestScenarioGroupEvidenceFile").matches()) {
-            if (testResourceManager != null && testResourceManager instanceof UploadableTestResourceManager) {
-                Map params = parseQuery(request.getHeader().getQuery());
-                OutputStream os = null;
-                try {
-                    parseMultipartRequest(request, contentType, params);
-                    String scenarioGroupId = (String) params.get("scenarioGroupId");
-                    testController.generateTestScenarioGroupEvidenceFile(scenarioGroupId);
-                } catch (Exception e) {
-                    if (isJSON) {
-                        Map jsonMap = new HashMap();
-                        jsonMap.put("exception", e);
-                        responseJSON(request, response, jsonMap);
-                    } else {
-                        responseBinary(response, e);
-                    }
-                } finally {
-                    if (os != null) {
-                        try {
-                            os.close();
-                        } catch (Exception e) {
-                        }
+            Map params = parseQuery(request.getHeader().getQuery());
+            if (body != null) {
+                params.putAll(parseQuery(body));
+            }
+            OutputStream os = null;
+            try {
+                String scenarioGroupId = getParameter(params, "scenarioGroupId");
+                testController.generateTestScenarioGroupEvidenceFile(scenarioGroupId);
+            } catch (Exception e) {
+                if (isJSON) {
+                    Map jsonMap = new HashMap();
+                    jsonMap.put("exception", e);
+                    responseJSON(request, response, jsonMap);
+                } else {
+                    responseBinary(response, e);
+                }
+            } finally {
+                if (os != null) {
+                    try {
+                        os.close();
+                    } catch (Exception e) {
                     }
                 }
             }
         } else if (request.getHeader().getURLMatcher(".*generateTestScenarioEvidenceFile").matches()) {
-            if (testResourceManager != null && testResourceManager instanceof UploadableTestResourceManager) {
-                Map params = parseQuery(request.getHeader().getQuery());
-                OutputStream os = null;
-                try {
-                    parseMultipartRequest(request, contentType, params);
-                    String scenarioGroupId = (String) params.get("scenarioGroupId");
-                    String scenarioId = (String) params.get("scenarioId");
-                    testController.generateTestScenarioEvidenceFile(scenarioGroupId, scenarioId);
-                } catch (Exception e) {
-                    if (isJSON) {
-                        Map jsonMap = new HashMap();
-                        jsonMap.put("exception", e);
-                        responseJSON(request, response, jsonMap);
-                    } else {
-                        responseBinary(response, e);
-                    }
-                } finally {
-                    if (os != null) {
-                        try {
-                            os.close();
-                        } catch (Exception e) {
-                        }
+            Map params = parseQuery(request.getHeader().getQuery());
+            if (body != null) {
+                params.putAll(parseQuery(body));
+            }
+            OutputStream os = null;
+            try {
+                String scenarioGroupId = getParameter(params, "scenarioGroupId");
+                String scenarioId = getParameter(params, "scenarioId");
+                testController.generateTestScenarioEvidenceFile(scenarioGroupId, scenarioId);
+            } catch (Exception e) {
+                if (isJSON) {
+                    Map jsonMap = new HashMap();
+                    jsonMap.put("exception", e);
+                    responseJSON(request, response, jsonMap);
+                } else {
+                    responseBinary(response, e);
+                }
+            } finally {
+                if (os != null) {
+                    try {
+                        os.close();
+                    } catch (Exception e) {
                     }
                 }
             }
         } else if (request.getHeader().getURLMatcher(".*generateTestCaseEvidenceFile").matches()) {
-            if (testResourceManager != null && testResourceManager instanceof UploadableTestResourceManager) {
-                Map params = parseQuery(request.getHeader().getQuery());
-                OutputStream os = null;
-                try {
-                    String scenarioGroupId = (String) params.get("scenarioGroupId");
-                    String scenarioId = (String) params.get("scenarioId");
-                    String testcaseId = (String) params.get("testcaseId");
-                    testController.generateTestCaseEvidenceFile(scenarioGroupId, scenarioId, testcaseId);
-                } catch (Exception e) {
-                    if (isJSON) {
-                        Map jsonMap = new HashMap();
-                        jsonMap.put("exception", e);
-                        responseJSON(request, response, jsonMap);
-                    } else {
-                        responseBinary(response, e);
-                    }
-                } finally {
-                    if (os != null) {
-                        try {
-                            os.close();
-                        } catch (Exception e) {
-                        }
+            Map params = parseQuery(request.getHeader().getQuery());
+            if (body != null) {
+                params.putAll(parseQuery(body));
+            }
+            OutputStream os = null;
+            try {
+                String scenarioGroupId = getParameter(params, "scenarioGroupId");
+                String scenarioId = getParameter(params, "scenarioId");
+                String testcaseId = getParameter(params, "testcaseId");
+                testController.generateTestCaseEvidenceFile(scenarioGroupId, scenarioId, testcaseId);
+            } catch (Exception e) {
+                if (isJSON) {
+                    Map jsonMap = new HashMap();
+                    jsonMap.put("exception", e);
+                    responseJSON(request, response, jsonMap);
+                } else {
+                    responseBinary(response, e);
+                }
+            } finally {
+                if (os != null) {
+                    try {
+                        os.close();
+                    } catch (Exception e) {
                     }
                 }
             }

--- a/src/main/java/jp/ossc/nimbus/service/test/evaluate/CSVCompareEvaluateActionService.java
+++ b/src/main/java/jp/ossc/nimbus/service/test/evaluate/CSVCompareEvaluateActionService.java
@@ -395,7 +395,7 @@ public class CSVCompareEvaluateActionService extends ServiceBase implements Eval
                     writeCSV(dstcsvw, dstcsv, ignores, ignoreRegexPatternMap);
                 }
                 result &= compareCSVList(srccsv, dstcsv, ignores, ignoreRegexPatternMap);
-            }while(isOutputFileAfterEdit ? (srccsv != null || dstcsv != null) : result);
+            }while(isOutputFileAfterEdit ? (srccsv != null || dstcsv != null) : (result && (srccsv != null || dstcsv != null)));
         }finally{
             if(srcisr != null){
                 try{


### PR DESCRIPTION
・ローカルにリソースがないと、エビデンス生成機能が使えない不具合を修正した。
・HTTPでエビデンス生成機能を呼び出すと、例外が発生する不具合を修正した。
・ファイルをコピーする際に、転送先が存在しないディレクトリのファイルだった場合、コピーできない不具合を修正した。
・CSV比較で、OutputFileAfterEdit=falseの場合、無限ループに陥る不具合を修正した。